### PR TITLE
Use MIT license in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
 
     <licenses>
         <license>
-            <name>GNU General Public License v3.0</name>
-            <url>https://www.gnu.org/licenses/gpl-3.0.de.html</url>
+            <name>MIT</name>
+            <url>https://opensource.org/licenses/mit-license.php</url>
             <distribution>repo</distribution>
         </license>
     </licenses>


### PR DESCRIPTION
The license file has been changed to the MIT license. This PR updates the `pom.xml` to match the license.

Fixes #1 